### PR TITLE
Disable irq service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,3 +31,6 @@ Library defines:
     - ``CM3CPP_ENABLE_IMPLISIT_DESTRUCTOR_CALLS`` — do not call
       ``assert(false)`` if dangerous destructor of library class is
       called.
+
+    - ``CM3CPP_CUSTOM_INTERRUPT_SERVICE`` — disable IInterruptable
+      and leave all opencm3 interrupt functions undeclared.

--- a/cm3cpp/irq/irq.cpp
+++ b/cm3cpp/irq/irq.cpp
@@ -11,6 +11,8 @@
 
 namespace cm3cpp {
 
+#ifndef CM3CPP_CUSTOM_INTERRUPT_SERVICE
+
 struct EmptyInterrupt : public IInterruptable
 {
     void call() {}
@@ -222,5 +224,7 @@ DEFINE_CALLBACK(dma2d_isr, ISR_DMA2D)
 #endif
 
 END_DECLS
+
+#endif  // CM3CPP_CUSTOM_INTERRUPT_SERVICE
 
 }  // namespace cm3cpp

--- a/cm3cpp/irq/irq.hpp
+++ b/cm3cpp/irq/irq.hpp
@@ -193,6 +193,7 @@ enum Interrupt : uint32_t
 };
 #endif
 
+#ifndef CM3CPP_CUSTOM_INTERRUPT_SERVICE
 class IInterruptable
 {
  public:
@@ -203,5 +204,6 @@ class IInterruptable
                              IInterruptable* interrupt_owner);
     virtual void call() = 0;
 };
+#endif
 
 } /* namespace cm3cpp */

--- a/cm3cpp/spi.cpp
+++ b/cm3cpp/spi.cpp
@@ -49,8 +49,6 @@ Spi::Spi(Config spi_conf)
             break;
     }
 
-    this->register_isr(_irq, this);
-
     Gpio mosi(spi_conf.mosi_pin);
     mosi.mode_setup(Gpio::Mode::ALTERNATE_FUNCTION, Gpio::PullMode::NO_PULL);
     mosi.set_output_options(Gpio::OutputType::PUSH_PULL,
@@ -181,8 +179,6 @@ inline void Spi::enable_nvic()
 {
     nvic_enable_irq(static_cast<uint8_t>(_irq));
 }
-
-void Spi::call() {}
 
 }  // namespace spi
 

--- a/cm3cpp/spi.hpp
+++ b/cm3cpp/spi.hpp
@@ -114,7 +114,7 @@ enum StdMode
     MODE_3
 };
 
-class Spi : public IInterruptable
+class Spi
 {
  public:
     using Gpio = gpio::Gpio;
@@ -129,8 +129,6 @@ class Spi : public IInterruptable
 
     Spi();
     Spi(Config spi_conf);
-
-    void call();
 
     bool get_flag_status(Flag flag) const;
 


### PR DESCRIPTION
Добавил define `CM3CPP_CUSTOM_INTERRUPT_SERVICE` для выключения реализации всех библиотечных Си-шных функций прерываний в файле irq.cpp. Больше хак, чем решение, конечно. Может понадобиться в случае, когда нужно входить в прерывания быстро без косвенных вызовов.