### PR TITLE
FIX: [systick] CM3CPP_CUSTOM_SYSTICK

### DIFF
--- a/cm3cpp/i2c.cpp
+++ b/cm3cpp/i2c.cpp
@@ -29,6 +29,8 @@ namespace cm3cpp {
 
 namespace i2c {
 
+#ifndef CM3CPP_CUSTOM_SYSTICK
+
 I2c::I2c(Config i2c_conf) :
   _counter_ms(new systick::Counter(systick::Counter::Mode::ONE_SHOT,
                                    MAX_TRANSMIT_TIME_MS))
@@ -351,6 +353,8 @@ auto I2c::_get_flag_status(Event event) -> Result
 
     return result;
 }
+
+#endif  // CM3CPP_CUSTOM_SYSTICK
 
 }  // namespace i2c
 

--- a/cm3cpp/i2c.hpp
+++ b/cm3cpp/i2c.hpp
@@ -37,6 +37,8 @@ namespace cm3cpp {
 
 namespace i2c {
 
+#ifndef CM3CPP_CUSTOM_SYSTICK
+
 class I2c
 {
  public:
@@ -212,6 +214,8 @@ class I2c
     void _disable_ack();
     Result _get_flag_status(Event event);
 };
+
+#endif  // CM3CPP_CUSTOM_SYSTICK
 
 }  // namespace i2c
 

--- a/cm3cpp/systick.cpp
+++ b/cm3cpp/systick.cpp
@@ -131,7 +131,8 @@ bool Counter::stop()
     return true;
 }
 
-}  // namespace systick
 #endif  // CM3CPP_CUSTOM_SYSTICK
+}  // namespace systick
+
 
 }  // namespace cm3cpp


### PR DESCRIPTION
С дефайном `CM3CPP_CUSTOM_SYSTICK` не собиралось. Поправил.