### PR TITLE
[usart] Add access to LL usart periph address

### DIFF
--- a/cm3cpp/usart.hpp
+++ b/cm3cpp/usart.hpp
@@ -190,6 +190,8 @@ class Usart
 
     auto get_irq() { return static_cast<Interrupt>(_usart_nvic); }
 
+    auto get_uart_periph() { return _usart; }
+
  protected:
     Gpio _rx;
     Gpio _tx;


### PR DESCRIPTION
It is necessary in some special cases, than part of needed
functional is not implemented in library.