### PR TITLE
GPIO port copy paste error

### DIFF
--- a/cm3cpp/gpio.hpp
+++ b/cm3cpp/gpio.hpp
@@ -62,7 +62,7 @@ class Gpio
 #endif
 #if (GPIOB + 0)
             ,
-            PORT_B = GPIOC
+            PORT_B = GPIOB
 #endif
 #if (GPIOC + 0)
             ,


### PR DESCRIPTION
Ошибка копипасты. Вмесато GPIOC продублирован GPIOB.

В рамках задачи #17987