### PR TITLE
Compilation fails because of pinout macros

### DIFF
--- a/cm3cpp/private/pinout.h
+++ b/cm3cpp/private/pinout.h
@@ -3,7 +3,8 @@
 
 #define PINOUT_CTOR(port, pin)                                                 \
     {                                                                          \
-        static_cast<Pinout::Port>(GPIO##port), GPIO##pin, pin                  \
+        static_cast<::cm3cpp::gpio::Gpio::Pinout::Port>(GPIO##port),           \
+          GPIO##pin, pin,                                                      \
     }
 
 #define PNULL                                                                  \


### PR DESCRIPTION
Макрос генерирует влидный код, только если `Pinout` находится в одном скопе с использованием макроса. Т.е.:
```cpp
{
   using Pinout = cm3cpp::gpio::Gpio::Pinout;
   Gpio pin(PA1);
}
```

Компилируется. А если первую строчку убрать, то нет с сообщением "Pinout::Port is not defined" или типа того.

Исправил макрос, сделал полное имя до `enum Port` от корневого namespace.

TASK-18929